### PR TITLE
Repair 'enter' key when in list, instead of grid, view

### DIFF
--- a/src/BuildMenuSearchHotkey/SearchClickHotkeys.cs
+++ b/src/BuildMenuSearchHotkey/SearchClickHotkeys.cs
@@ -1,8 +1,10 @@
 ﻿using HarmonyLib;
 using System;
 using System.Collections;
+using System.Collections.Generic;
 using System.Linq;
 using UnityEngine;
+using UnityEngine.UI;
 
 namespace BuildMenuSearchHotkey;
 
@@ -38,11 +40,7 @@ class SearchClickHotkeys
 
         static void SelectToggle(int toggleIndex, Action<PlanBuildingToggle> selectAction)
         {
-            // The displayed order of buttons is set by changing the sibling index.
-            // Thus, these must be accessed through the transform to get the correct order.
-            var parent = PlanScreen.Instance.allBuildingToggles.Values.FirstOrDefault()?.transform.parent;
-            var children = parent.Cast<Transform>().Where(x => x.gameObject.activeSelf);
-            var toggle = children.ElementAtOrDefault(toggleIndex)?.GetComponent<PlanBuildingToggle>();
+            var toggle = GetVisibleTogglesInDisplayOrder().ElementAtOrDefault(toggleIndex);
             if (toggle != null)
             {
                 // Klei's input system exists simultaneously with Unity's.
@@ -56,6 +54,31 @@ class SearchClickHotkeys
                     while (Input.anyKeyDown)
                         yield return null;
                     onPast();
+                }
+            }
+        }
+
+        // Walks the build menu hierarchy in display order, yielding visible (search-filtered) toggles.
+        // Works for both grid view and list view: the game sorts subcategory containers and the toggles
+        // inside each subcategory's grid by score via SetAsLastSibling, so transform child order
+        // already matches display order. In grid view only the "default" subcategory is active and
+        // contains every toggle; in list view multiple subcategories may each be active.
+        static IEnumerable<PlanBuildingToggle> GetVisibleTogglesInDisplayOrder()
+        {
+            foreach (Transform subcategory in PlanScreen.Instance.GroupsTransform)
+            {
+                if (!subcategory.gameObject.activeSelf)
+                    continue;
+                var grid = subcategory.GetComponent<HierarchyReferences>()?.GetReference<GridLayoutGroup>("Grid");
+                if (grid == null)
+                    continue;
+                foreach (Transform child in grid.transform)
+                {
+                    if (!child.gameObject.activeSelf)
+                        continue;
+                    var toggle = child.GetComponent<PlanBuildingToggle>();
+                    if (toggle != null)
+                        yield return toggle;
                 }
             }
         }


### PR DESCRIPTION
At the moment the mod doesn't function unless you're in the default grid view - the built-in list-view uses a different container layout.

This PR fixes that; everything I tested still works correctly, but let me know if I missed anything1