### PR TITLE
(Optionally) prefer an exact match when searching

### DIFF
--- a/Translations/BuildMenuSearchHotkey/buildmenusearchhotkey_template.pot
+++ b/Translations/BuildMenuSearchHotkey/buildmenusearchhotkey_template.pot
@@ -1,0 +1,13 @@
+msgid ""
+msgstr ""
+"Application: Oxygen Not Included"
+"POT Version: 2.0"
+
+msgctxt "BuildMenuSearchHotkey.OPTIONS.PREFEREXACTNAMEMATCH.NAME"
+msgid "Prefer Exact Name Match"
+msgstr ""
+
+msgctxt "BuildMenuSearchHotkey.OPTIONS.PREFEREXACTNAMEMATCH.TOOLTIP"
+msgid "When pressing Enter, prefer a building whose name exactly matches the search query (case-insensitive) over the fuzzy-ranked top result. Disable to always pick the top fuzzy result."
+msgstr ""
+

--- a/src/BuildMenuSearchHotkey/Options.cs
+++ b/src/BuildMenuSearchHotkey/Options.cs
@@ -1,0 +1,14 @@
+using AzeLib;
+using PeterHan.PLib.Options;
+
+namespace BuildMenuSearchHotkey;
+
+public class Options : BaseOptions<Options>
+{
+    [Option] public bool PreferExactNameMatch { get; set; }
+
+    public Options()
+    {
+        PreferExactNameMatch = true;
+    }
+}

--- a/src/BuildMenuSearchHotkey/STRINGS.cs
+++ b/src/BuildMenuSearchHotkey/STRINGS.cs
@@ -1,0 +1,12 @@
+using AzeLib;
+
+namespace BuildMenuSearchHotkey;
+
+public class OPTIONS : AStrings<OPTIONS>
+{
+    public class PREFEREXACTNAMEMATCH
+    {
+        public static LocString NAME = "Prefer Exact Name Match";
+        public static LocString TOOLTIP = "When pressing Enter, prefer a building whose name exactly matches the search query (case-insensitive) over the fuzzy-ranked top result. Disable to always pick the top fuzzy result.";
+    }
+}

--- a/src/BuildMenuSearchHotkey/SearchClickHotkeys.cs
+++ b/src/BuildMenuSearchHotkey/SearchClickHotkeys.cs
@@ -14,11 +14,20 @@ class SearchClickHotkeys
     static void Postfix()
     {
         // While typing, press Enter to select the first result.
+        // An exact (case-insensitive) name match wins over the fuzzy-ranked top, so e.g. "Ladder" picks
+        // the building literally named "Ladder" even when the fuzzy score puts something else above it.
         BuildingGroupScreen.Instance.inputField.onEndEdit.AddListener((string str) =>
         {
             // onSubmit handler never triggers, so this needs to be checked manually.
             if (Input.GetKeyDown(KeyCode.Return))
-                SelectToggle(0, (PlanBuildingToggle toggle) => toggle.Click());
+                SelectToggle(toggles =>
+                {
+                    // SearchUtil.Canonicalize strips rich-text (e.g. <link="LADDER">Ladder</link>) and uppercases,
+                    // matching the form the game's own fuzzy search uses — so we compare apples to apples.
+                    var query = SearchUtil.Canonicalize(str.Trim());
+                    return toggles.FirstOrDefault(t => SearchUtil.Canonicalize(t.def.Name) == query)
+                        ?? toggles.FirstOrDefault();
+                }, (PlanBuildingToggle toggle) => toggle.Click());
         });
 
         // While typing, press 1-9 to select the corresponding result.
@@ -26,7 +35,7 @@ class SearchClickHotkeys
         {
             if (int.TryParse(addedChar.ToString(), out var num))
             {
-                SelectToggle(num - 1, (PlanBuildingToggle toggle) =>
+                SelectToggle(toggles => toggles.ElementAtOrDefault(num - 1), (PlanBuildingToggle toggle) =>
                 {
                     BuildingGroupScreen.Instance.inputField.DeactivateInputField();
                     toggle.Click();
@@ -38,9 +47,9 @@ class SearchClickHotkeys
             return addedChar;
         };
 
-        static void SelectToggle(int toggleIndex, Action<PlanBuildingToggle> selectAction)
+        static void SelectToggle(Func<IEnumerable<PlanBuildingToggle>, PlanBuildingToggle> pick, Action<PlanBuildingToggle> selectAction)
         {
-            var toggle = GetVisibleTogglesInDisplayOrder().ElementAtOrDefault(toggleIndex);
+            var toggle = pick(GetVisibleTogglesInDisplayOrder());
             if (toggle != null)
             {
                 // Klei's input system exists simultaneously with Unity's.

--- a/src/BuildMenuSearchHotkey/SearchClickHotkeys.cs
+++ b/src/BuildMenuSearchHotkey/SearchClickHotkeys.cs
@@ -22,6 +22,9 @@ class SearchClickHotkeys
             if (Input.GetKeyDown(KeyCode.Return))
                 SelectToggle(toggles =>
                 {
+                    if (!Options.Opts.PreferExactNameMatch)
+                        return toggles.FirstOrDefault();
+
                     // SearchUtil.Canonicalize strips rich-text (e.g. <link="LADDER">Ladder</link>) and uppercases,
                     // matching the form the game's own fuzzy search uses — so we compare apples to apples.
                     var query = SearchUtil.Canonicalize(str.Trim());

--- a/src/BuildMenuSearchHotkey/SearchClickHotkeys.cs
+++ b/src/BuildMenuSearchHotkey/SearchClickHotkeys.cs
@@ -1,8 +1,10 @@
 ﻿using HarmonyLib;
 using System;
 using System.Collections;
+using System.Collections.Generic;
 using System.Linq;
 using UnityEngine;
+using UnityEngine.UI;
 
 namespace BuildMenuSearchHotkey;
 
@@ -38,11 +40,7 @@ class SearchClickHotkeys
 
         static void SelectToggle(int toggleIndex, Action<PlanBuildingToggle> selectAction)
         {
-            // The displayed order of buttons is set by changing the sibling index.
-            // Thus, these must be accessed through the transform to get the correct order.
-            var parent = PlanScreen.Instance.allBuildingToggles.Values.FirstOrDefault()?.transform.parent;
-            var children = parent.Cast<Transform>().Where(x => x.gameObject.activeSelf);
-            var toggle = children.ElementAtOrDefault(toggleIndex)?.GetComponent<PlanBuildingToggle>();
+            var toggle = GetVisibleTogglesInDisplayOrder().ElementAtOrDefault(toggleIndex);
             if (toggle != null)
             {
                 // Klei's input system exists simultaneously with Unity's.
@@ -56,6 +54,31 @@ class SearchClickHotkeys
                     while (Input.anyKeyDown)
                         yield return null;
                     onPast();
+                }
+            }
+        }
+
+        // Walks the build menu hierarchy in display order, yielding visible (search-filtered) toggles.
+        // Works for both grid view and list view: the game sorts subcategory containers and the toggles
+        // inside each subcategory's grid by score via SetAsLastSibling, so transform child order
+        // already matches display order. In grid view only the "default" subcategory is active and
+        // contains every toggle; in list view multiple subcategories may each be active.
+        static IEnumerable<PlanBuildingToggle> GetVisibleTogglesInDisplayOrder()
+        {
+            foreach (Transform subcategory in PlanScreen.Instance.GroupsTransform)
+            {
+                if (!subcategory.gameObject.activeSelf)
+                    continue;
+                var grid = subcategory.GetComponent<HierarchyReferences>()?.GetReference<GridLayoutGroup>("Grid");
+                if (grid == null)
+                    continue;
+                foreach (Transform child in grid.transform)
+                {
+                    if (!child.gameObject.activeSelf)
+                        continue;
+                    var toggle = child.GetComponent<PlanBuildingToggle>();
+                    if (toggle != null)
+                        yield return toggle;
                 }
             }
         }


### PR DESCRIPTION
At the moment, if I type "ladder" and hit return, I get "ladder bed." That's almost never what I want, haha.

With this patch, if there's a (case-insensitive) exact match, that will always be chosen.

I also added a config option to disable that behaviour, for people who prefer the fuzzy search always behave exactly the same. (This PR is built on top of #69; so merge that first.)