### PR TITLE
Fix `dotnet build` for non-VS users

### DIFF
--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -1,9 +1,8 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project>
 
-  <!--User Configuration-->
-  <Import Project="Directory.Build.props.default" />
   <Import Condition=" Exists('Directory.Build.props.user') " Project="Directory.Build.props.user" />
+  <Import Project="Directory.Build.props.default" />
 
   <!--Base Settings-->
   <PropertyGroup>
@@ -60,14 +59,7 @@
   <PropertyGroup>
     <TranslationsFolder>..\..\Translations</TranslationsFolder> <!--This must be changed in AzeLib.AzeLocalization.GeneratePOTemplates as well.-->
   </PropertyGroup>
-  
-  <!--Direct the output locations based on build configuration.-->
-  <PropertyGroup Condition=" '$(Configuration)' == 'Release' ">
-    <InstallFolder>..\..\Release\$(MSBuildProjectName)</InstallFolder>
-    <DistributeFolder>..\..\Distribute\</DistributeFolder>
-  </PropertyGroup>
-  <PropertyGroup Condition=" '$(Configuration)' == 'Debug' ">
-    <InstallFolder>$(ModFolder)\DEV_$(MSBuildProjectName)</InstallFolder>
-  </PropertyGroup>
+
+  <!-- InstallFolder/DistributeFolder are now defined in Directory.Build.targets. -->
 
 </Project>

--- a/src/Directory.Build.props.default
+++ b/src/Directory.Build.props.default
@@ -1,8 +1,8 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <Project>
   <PropertyGroup>
-    <SteamFolder>C:\Program Files (x86)\Steam</SteamFolder>
-    <GameFolder>$(SteamFolder)\steamapps\common\OxygenNotIncluded\OxygenNotIncluded_Data\Managed</GameFolder>
-    <ModFolder>$(UserProfile)\Documents\Klei\OxygenNotIncluded\mods\dev</ModFolder>
+    <SteamFolder Condition=" '$(SteamFolder)' == '' ">C:\Program Files (x86)\Steam</SteamFolder>
+    <GameFolder Condition=" '$(GameFolder)' == '' ">$(SteamFolder)\steamapps\common\OxygenNotIncluded\OxygenNotIncluded_Data\Managed</GameFolder>
+    <ModFolder Condition=" '$(ModFolder)' == '' ">$(UserProfile)\Documents\Klei\OxygenNotIncluded\mods\dev</ModFolder>
   </PropertyGroup>
 </Project>

--- a/src/Directory.Build.targets
+++ b/src/Directory.Build.targets
@@ -1,6 +1,15 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project>
 
+  <!--Direct the output locations based on build configuration.-->
+  <PropertyGroup Condition=" '$(Configuration)' == 'Release' ">
+    <InstallFolder>..\..\Release\$(MSBuildProjectName)</InstallFolder>
+    <DistributeFolder>..\..\Distribute\</DistributeFolder>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)' == 'Debug' ">
+    <InstallFolder>$(ModFolder)\DEV_$(MSBuildProjectName)</InstallFolder>
+  </PropertyGroup>
+
   <!--Ignore the contents of the Previews folder.-->
   <ItemGroup>
     <Compile Remove="Previews\**" />
@@ -9,15 +18,15 @@
   </ItemGroup>
 
   <!--Publicise the game's assemblies on rebuilds.-->
-  <Target Name="Publicise" AfterTargets="Clean" Condition="'$(MSBuildProjectName)' == 'AzeLib'">
+  <Target Name="Publicise" AfterTargets="Clean" Condition="'$(MSBuildProjectName)' == 'AzeLib' And '$(MSBuildRuntimeType)' != 'Core'">
     <Publicise
       InputAssemblies="@(PubliciseInputAssemblies)"
       OutputPath="../lib/"/>
   </Target>
 
   <!--Increment the version number after each build, resetting each day.-->
-  <Import Project="AutoIncrement.targets" />
-  <Target Name="AutoIncrement" BeforeTargets="PrepareForBuild">
+  <Import Project="AutoIncrement.targets" Condition="'$(MSBuildRuntimeType)' != 'Core'" />
+  <Target Name="AutoIncrement" BeforeTargets="PrepareForBuild" Condition="'$(MSBuildRuntimeType)' != 'Core'">
     <AutoIncrement Path="$(IntermediateOutputPath)">
       <Output
         PropertyName="ProjectRevision"
@@ -62,8 +71,11 @@
         Include ="$(TargetDir)\*.dll"
         Exclude ="$(TargetPath); **/System.*"/>
     </ItemGroup>
+    <PropertyGroup>
+      <ILRepackTargetPlatformVersion Condition=" '$(MSBuildRuntimeType)' != 'Core' ">v4</ILRepackTargetPlatformVersion>
+    </PropertyGroup>
     <ILRepack
-      TargetPlatformVersion="v4"
+      TargetPlatformVersion="$(ILRepackTargetPlatformVersion)"
 			TargetKind="SameAsPrimaryAssembly"
 			OutputFile="$(TargetPath)"
 			InputAssemblies="@(InputAssemblies)"

--- a/src/README.md
+++ b/src/README.md
@@ -19,9 +19,24 @@ Compiling this solution is fairly simple.  If you run into issues, feel free to 
 
 Depending on the build configuration, the mods will be handled differently.
 
-- Debug: 
+- Debug:
   - Prefixed with `DEV_`
   - Exported to ONI's `mods\dev` folder.
 - Release:
   - Exported to the Release folder
   - Zipped and placed in the [Distribute](https://github.com/AzeTheGreat/ONI-Mods/tree/master/Distribute) folder
+
+## Without Visual Studio
+
+`dotnet build` also works (VS Code, Rider, etc.). Two caveats since `Aze.Publicise` and `AutoIncrement` only run under .NET Framework MSBuild:
+
+- Publicized refs (`src/lib/*_public.dll`) won't auto-generate. Once after cloning, and after ONI updates:
+
+  ```sh
+  dotnet tool install -g BepInEx.AssemblyPublicizer.Cli
+  for dll in Assembly-CSharp Assembly-CSharp-firstpass Unity.TextMeshPro; do
+    assembly-publicizer "$GameFolder/$dll.dll" -o "src/lib/${dll}_public.dll"
+  done
+  ```
+
+- `version.json` won't bump per build. Cut releases through Visual Studio.


### PR DESCRIPTION
This doesn't affect any of the mods, and shouldn't affect your workflow if I did it right; but this gets `dotnet build` working outside of Visual Studio. (How I've been compiling your work as I patch things.)

Not really critical; it's fine if you don't want to maintain a workflow you yourself don't use - no hard feelings if this PR is declined. (=